### PR TITLE
Fix TinyMCE 3 format select box

### DIFF
--- a/source/plugins/tinymce/inits/init_full.js
+++ b/source/plugins/tinymce/inits/init_full.js
@@ -24,7 +24,7 @@
     theme_advanced_resizing : true,
 
     // %PAGEHEADERS% = h1...hx for new pages, %NAMED_PAGEHEADERS% =  1. Level pageheader=h1 ...hx, %HEADERS% = remaining hy...h6
-    theme_advanced_blockformats : "%HEADERS%,p=p,div=div,%PAGEHEADERS%,code=code,pre=pre,dt=dt,dd=dd",
+    theme_advanced_blockformats : "%PAGEHEADERS%,%HEADERS%,p=p,div=div,code=code,pre=pre,dt=dt,dd=dd",
     theme_advanced_font_sizes : "8px=8px,10px=10px,12px=12px,14px=14px,16px=16px,18px=18px,20px=20px,24px=24px,36px=36px",
 
     content_css : "%STYLESHEET%",

--- a/source/plugins/tinymce/inits/init_medium.js
+++ b/source/plugins/tinymce/inits/init_medium.js
@@ -23,7 +23,7 @@
     theme_advanced_resizing : true,
 
     // %PAGEHEADERS% = h1...hx for new pages, %NAMED_PAGEHEADERS% =  1. Level pageheader=h1 ...hx, %HEADERS% = remaining hy...h6
-    theme_advanced_blockformats : "%HEADERS%,p=p,div=div,%PAGEHEADERS%,code=code",
+    theme_advanced_blockformats : "%PAGEHEADERS%,%HEADERS%,p=p,div=div,code=code",
     theme_advanced_font_sizes : "8px=8px,10px=10px,12px=12px,14px=14px,16px=16px,18px=18px,20px=20px,24px=24px,36px=36px",
 
     content_css : "%STYLESHEET%",

--- a/source/plugins/tinymce/inits/init_minimal.js
+++ b/source/plugins/tinymce/inits/init_minimal.js
@@ -21,7 +21,7 @@
     theme_advanced_resizing : true,
 
     // %PAGEHEADERS% = h1...hx for new pages, %NAMED_PAGEHEADERS% =  1. Level pageheader=h1 ...hx, %HEADERS% = remaining hy...h6
-    theme_advanced_blockformats : "%HEADERS%,p=p,div=div,%PAGEHEADERS%",
+    theme_advanced_blockformats : "%PAGEHEADERS%,%HEADERS%,p=p,div=div",
     theme_advanced_font_sizes : "8px=8px,10px=10px,12px=12px,14px=14px,16px=16px,18px=18px,20px=20px,24px=24px,36px=36px",
 
     content_css : "%STYLESHEET%",

--- a/source/plugins/tinymce/inits/init_sidebar.js
+++ b/source/plugins/tinymce/inits/init_sidebar.js
@@ -15,7 +15,7 @@
     theme_advanced_resizing : true,
 
     // %PAGEHEADERS% = h1...hx for new pages, %NAMED_PAGEHEADERS% =  1. Level pageheader=h1 ...hx, %HEADERS% = remaining hy...h6
-    theme_advanced_blockformats : "%HEADERS%,p=p,div=div,%PAGEHEADERS%",
+    theme_advanced_blockformats : "%PAGEHEADERS%,%HEADERS%,p=p,div=div",
     theme_advanced_font_sizes : "8px=8px,10px=10px,12px=12px,14px=14px,16px=16px,18px=18px,20px=20px,24px=24px,36px=36px",
 
     content_css : "%STYLESHEET%",


### PR DESCRIPTION
There is no difference between page headings and internal headings
anymore, so we present all headings consecutively in the format select
box.

Actually, we should remove the %PAGEHEADERS% and %HEADERS% placeholders
altogether, but as TinyMCE 3 will likely be removed for XH 1.7 we don't
care to do so.