### PR TITLE
Fix newsbox() heading removal

### DIFF
--- a/source/cmsimple/functions.php
+++ b/source/cmsimple/functions.php
@@ -364,8 +364,7 @@ function newsbox($heading)
 
     for ($i = 0; $i < $cl; $i++) {
         if ($h[$i] == $heading) {
-            $pattern = "/.*<\/h[1-".$cf['menu']['levels']."]>/is";
-            $body = preg_replace($pattern, "", $c[$i]);
+            $body = $c[$i];
             $pattern = '/#CMSimple (.*?)#/is';
             return $edit
                 ? $body

--- a/source/content/content.htm
+++ b/source/content/content.htm
@@ -227,7 +227,7 @@ $page_data[]=array(
 <?php
 $page_data[]=array(
 'url'=>'Download',
-'last_edit'=>'1480026665',
+'last_edit'=>'1480202801',
 'description'=>'',
 'keywords'=>'',
 'title'=>'',
@@ -244,7 +244,15 @@ $page_data[]=array(
 'use_header_location'=>''
 );
 ?>
-</p>
 <p> </p>
 <p style="text-align: center;"><a href="./?download=XH_split_demo2_2016-11-24-001.zip"><strong>XH_split_demo2_2016-11-24-001</strong></a></p>
+<!--XH_ml1:News01-->
+<?php
+$page_data[]=array(
+'url'=>'News01',
+'last_edit'=>'1480202801'
+);
+?>
+<h1>News</h1>
+<p>Here you can read the latest news.</p>
 </body></html>


### PR DESCRIPTION
There shouldn't be any restriction regarding the headings of newsbox
pages, so we remove the code that strips the newsbox page heading.

We also add a News01 page to demonstrate the behavior.