### PR TITLE
Fix #6: Pagemanager cannot create pages

### DIFF
--- a/source/plugins/pagemanager/classes/XMLParser.php
+++ b/source/plugins/pagemanager/classes/XMLParser.php
@@ -257,8 +257,7 @@ class Pagemanager_XMLParser
             }
             $this->newContents[] = $content;
         } else {
-            $this->newContents[] = '<h' . $this->level . '>' . $this->title
-                . '</h' . $this->level . '>';
+            $this->newContents[] = "<!--XH_ml{$this->level}:{$this->title}-->";
         }
         if (isset($this->id)) {
             $pageData = $pd_router->find_page($this->id);


### PR DESCRIPTION
We also have to insert the split marker for newly created pages,
instead of the old heading marker.