### PR TITLE
Fix #2: Limit menulevels

### DIFF
--- a/source/cmsimple/adminfuncs.php
+++ b/source/cmsimple/adminfuncs.php
@@ -855,7 +855,7 @@ function XH_contentEditor()
         $o .= tag('input type="hidden" name="level" value="' . $l[$s] . '"') //HI
             . tag('input type="hidden" name="heading" value="' . $h[$s] . '"'); //HI
         //replace split-markers
-        $c[$s] = preg_replace('/<!--XH_ml[1-9]+:.*?-->/isu', '', $c[$s]); //HI
+        $c[$s] = preg_replace('/<!--XH_ml[1-9]:.*?-->/isu', '', $c[$s]); //HI
     }
     $o .= tag('input type="hidden" name="function" value="save"')
         . '<textarea name="text" id="text" class="xh-editor" style="height: '
@@ -900,7 +900,7 @@ function XH_saveContents()
         return false;
     }
     //HI $hot = '<h[1-' . $cf['menu']['levels'] . '][^>]*>'; //Core
-    $hot = '<!--XH_ml[1-9]+:';
+    $hot = '<!--XH_ml[1-9]:';
     //$hot = '<!--XH_ml[1-' . $cf['menu']['levels'] . ']-->[^>]*<h[1-6][^>]*>';
     //HI $hct = '<\/h[1-' . $cf['menu']['levels'] . ']>';
     //$hct = '<\/h[1-6]>';
@@ -947,14 +947,14 @@ function XH_saveEditorContents($text)
     $text = stsl($text);
     //clean up and inject split-markers
     if (!$cf['mode']['advanced']) {
-        $text = preg_replace('/<!--XH_ml[1-9]+:.*?-->/isu', '', $text);
+        $text = preg_replace('/<!--XH_ml[1-9]:.*?-->/isu', '', $text);
         $split = '<!--XH_ml' . stsl($_POST['level']) . ':' 
             . stsl($_POST['heading']) . '-->'
             . "\n";
         $text = $split . $text;
     }
     //HI $hot = '<h[1-' . $cf['menu']['levels'] . '][^>]*>'; //Core
-    $hot = '<!--XH_ml[1-9]+:';
+    $hot = '<!--XH_ml[1-9]:';
     //HI $hct = '<\/h[1-' . $cf['menu']['levels'] . ']>'; // TODO: use $1 ? //Core
     $hct = '-->';
     // TODO: this might be done before the plugins are loaded
@@ -970,7 +970,7 @@ function XH_saveEditorContents($text)
     // handle missing heading on the first page
     if ($s == 0) {
         //HI if (!preg_match('/^<h1[^>]*>.*<\/h1>/isu', $text) //Core
-        if (!preg_match('/^<!--XH_ml[1-9]+:.+-->/isu', $text)
+        if (!preg_match('/^<!--XH_ml[1-9]:.+-->/isu', $text)
             && !preg_match('/^(<p[^>]*>)?(\&nbsp;| |<br \/>)?(<\/p>)?$/isu', $text)
         ) {
             //HI $text = '<h1>' . $tx['toc']['missing'] . '</h1>' . "\n" . $text;
@@ -982,7 +982,7 @@ function XH_saveEditorContents($text)
     // insert $text to $c
     $text = preg_replace(
         //HI '/<h[1-' . $cf['menu']['levels'] . ']/i', "\x00" . '$0', $text
-        '/<!--XH_ml[1-9]+:/is', "\x00" . '$0', $text
+        '/<!--XH_ml[1-9]:/is', "\x00" . '$0', $text
     );
     $pages = explode("\x00", $text);
     

--- a/source/cmsimple/classes/Search.php
+++ b/source/cmsimple/classes/Search.php
@@ -157,7 +157,7 @@ class XH_Search
         $s = $pageIndex;
         //HI we have to add the page heading, if visible in content
         if ($cf['headings']['show']) {
-            //preg_match('/<!--XH_ml[1-9]+:(.+)-->/isU', $content, $matches);
+            //preg_match('/<!--XH_ml[1-9]:(.+)-->/isU', $content, $matches);
             //$content = $matches[1] . $content;
             $content = $h[$s] . $content;
         }

--- a/source/cmsimple/functions.php
+++ b/source/cmsimple/functions.php
@@ -924,14 +924,14 @@ function XH_readContents($language = null)
     }
     //$stop = $cf['menu']['levels'];
     //$content = preg_split('/(?=<h[1-' . $stop . '])/i', $content); //Core
-    $content = preg_split('/(?=<!--XH_ml[1-9]+:)/i', $content);
+    $content = preg_split('/(?=<!--XH_ml[1-9]:)/i', $content);
     $content[] = preg_replace('/(.*?)<\/body>.*/isu', '$1', array_pop($content));
     $contentHead = array_shift($content);
     $temp_h = array();
     foreach ($content as $page) {
         $c[] = $page;
         //preg_match('~<h([1-' . $stop . ']).*>(.*)</h~isU', $page, $temp); //Core
-        preg_match('~<!--XH_ml([1-9]+):(.*)-->~isU', $page, $temp);
+        preg_match('~<!--XH_ml([1-9]):(.*)-->~isU', $page, $temp);
         $l[] = $temp[1];
         $temp_h[] = trim(xh_rmws(strip_tags($temp[2])));
     }

--- a/source/cmsimple/tplfuncs.php
+++ b/source/cmsimple/tplfuncs.php
@@ -541,7 +541,7 @@ function content()
     $heading = '';
 
     if ($cf['headings']['show'] && $s > -1) {
-        if (preg_match('/<!--XH_ml[1-9]+:(.+)-->/isU', $c[$s], $matches)) {
+        if (preg_match('/<!--XH_ml[1-9]:(.+)-->/isU', $c[$s], $matches)) {
             $heading = $matches[1];
         } 
     }
@@ -555,13 +555,13 @@ function content()
         //return $o . preg_replace('/#CMSimple (.*?)#/is', '', $c[$s]); //HI
         $o .= sprintf($cf['headings']['format'], $heading) 
             . preg_replace('/#CMSimple (.*?)#/is', '', $c[$s]);
-        return  preg_replace('/<!--XH_ml[1-9]+:.*?-->/isu', '', $o);
+        return  preg_replace('/<!--XH_ml[1-9]:.*?-->/isu', '', $o);
     } else {
         //return $o; //HI
         if ($s > -1 && ($cf['headings']['show'] || ($edit && XH_ADM))) {
             $o = sprintf($cf['headings']['format'], $h[$s]) . $o;
         }
-        return  preg_replace('/<!--XH_ml[1-9]+:.*?-->/isu', '', $o);
+        return  preg_replace('/<!--XH_ml[1-9]:.*?-->/isu', '', $o);
     }
 }
 

--- a/source/plugins/page_params/index.php
+++ b/source/plugins/page_params/index.php
@@ -179,7 +179,7 @@ if (!$edit && $pd_current) {
         $temp = '/(<h[1-' . $cf['menu']['levels'] . '].*>).+(<\/h[1-'
             . $cf['menu']['levels'] . ']>)/isU';
         */
-        $temp = '/(<!--XH_ml[1-9]+:).+(-->)/isU'; //HI
+        $temp = '/(<!--XH_ml[1-9]:).+(-->)/isU'; //HI
         if (trim($pd_current['heading']) == '') {
             $c[$pd_s] = preg_replace($temp, '', $c[$pd_s]);
         } else {


### PR DESCRIPTION
We limit the supported menu-levels to 9, to avoid way too long page
URLs which could be truncated due to `$cf[uri][length]`, what might
lead to confusion.

We do *not* change anything related to `$cf[menu][levelcatch]` with this
patch.