### PR TITLE
Fix menulevel handling in Pagemanager

### DIFF
--- a/source/plugins/pagemanager/classes/Controller.php
+++ b/source/plugins/pagemanager/classes/Controller.php
@@ -245,7 +245,7 @@ class Pagemanager_Controller
             'okButton' => $ptx['button_ok'],
             'cancelButton' => $ptx['button_cancel'],
             'deleteButton' => $ptx['button_delete'],
-            'menuLevels' => (int) $cf['menu']['levels'],
+            'menuLevels' => 9,
             'verbose' => (bool) $pcf['verbose'],
             'menuLevelMessage' => $ptx['message_menu_level'],
             'cantRenameError' => $ptx['error_cant_rename'],

--- a/source/plugins/pagemanager/classes/Model.php
+++ b/source/plugins/pagemanager/classes/Model.php
@@ -96,7 +96,6 @@ class Pagemanager_Model
     {
         global $c, $h, $cf, $tx;
 
-        $stop = $cf['menu']['levels'];
         $empty = 0;
         foreach ($c as $i => $page) {
             $heading = $this->cleanedHeading($h[$i]);
@@ -176,7 +175,7 @@ class Pagemanager_Model
 
         include_once "{$pth['folder']['plugins']}pagemanager/classes/XMLParser.php";
         $parser = new Pagemanager_XMLParser(
-            $c, (int) $cf['menu']['levels'],
+            $c,
             $plugin_cf['pagemanager']['pagedata_attribute']
         );
         $parser->parse($xml);

--- a/source/plugins/pagemanager/classes/XMLParser.php
+++ b/source/plugins/pagemanager/classes/XMLParser.php
@@ -53,15 +53,6 @@ class Pagemanager_XMLParser
     var $pageData;
 
     /**
-     * The maximum nesting level.
-     *
-     * @var int
-     *
-     * @access protected
-     */
-    var $levels;
-
-    /**
      * The current nesting level.
      *
      * @var int
@@ -119,15 +110,13 @@ class Pagemanager_XMLParser
      * Initializes a newly created object.
      *
      * @param array  $contents   Page contents.
-     * @param int    $levels     Maximum page level.
      * @param string $pdattrName Name of a page data attribute.
      *
      * @return void
      */
-    function Pagemanager_XMLParser($contents, $levels, $pdattrName)
+    function Pagemanager_XMLParser($contents, $pdattrName)
     {
         $this->contents = $contents;
-        $this->levels = $levels;
         $this->pdattrName = $pdattrName;
     }
 


### PR DESCRIPTION
The Pagemanager still used `$cf[menu][levels]` what limits deeper
nesting than what is already there. Instead we have to use the maximum
nesting level, which is currently 9 (a constant appears to be useful
here, by the way).

We also remove two more `$cf[menu][levels]` which are not used anymore.